### PR TITLE
Kalunge/create new user account api endpoint

### DIFF
--- a/api/app/controllers/user_controller.rb
+++ b/api/app/controllers/user_controller.rb
@@ -2,7 +2,45 @@ require 'sinatra'
 require 'jwt'
 
 class UserController < Sinatra::Base
+  JWT_SECRET = 'my$ecretK3y'
 
+  # @API: Enable CORS headers from all origins
+  configure do
+    enable :cross_origin
+  end
+
+  before do
+    response.headers['Access-Control-Allow-Origin'] = '*'
+  end
+
+  options '*' do
+
+    response.headers['Allow'] = 'GET, PUT, POST, DELETE, OPTIONS'
+    response.headers['Access-Control-Allow-Headers'] = 'Authorization, Content-Type, Accept, X-User-Email, X-Auth-Token'
+    response.headers['Access-Control-Allow-Origin'] = '*'
+    200
+  end
+
+  # @API: Format all JSON responses
+  def json_response(code: 200, data: nil)
+    status = [200, 201].include?(code) ? 'SUCCESS' : 'FAILED'
+    headers['Content-Type'] = 'application/json'
+    return unless data
+
+    [code, { data: data, message: status }.to_json]
+  end
+
+  # @API: Format all common error responses as JSON (thrown errors)
+  def error_response(err:, code: 422)
+    json_response(code: code, data: { error: err.message })
+  end
+
+  # @API: 404 handler
+  not_found do
+    json_response(code: 404, data: { error: 'You seem lost. That page does not exist!' })
+  end
+
+  
   
 
 end

--- a/api/app/controllers/user_controller.rb
+++ b/api/app/controllers/user_controller.rb
@@ -14,7 +14,6 @@ class UserController < Sinatra::Base
   end
 
   options '*' do
-
     response.headers['Allow'] = 'GET, PUT, POST, DELETE, OPTIONS'
     response.headers['Access-Control-Allow-Headers'] = 'Authorization, Content-Type, Accept, X-User-Email, X-Auth-Token'
     response.headers['Access-Control-Allow-Origin'] = '*'
@@ -59,8 +58,14 @@ class UserController < Sinatra::Base
     user = User.new(email: email, password: password, token: token)
     user.save
 
+    # check if user save is successful
+    if user.errors.any?
+      error_response(err: user.errors.full_messages.join(', '))
+    end
+
     json_response(code: 201, data: { token: token })
   end
   
+
 
 end

--- a/api/app/controllers/user_controller.rb
+++ b/api/app/controllers/user_controller.rb
@@ -40,7 +40,27 @@ class UserController < Sinatra::Base
     json_response(code: 404, data: { error: 'You seem lost. That page does not exist!' })
   end
 
-  
+  # @API: Register a new user
+  post '/register' do
+    data = JSON.parse(request.body.read)
+
+    email = data['email']
+    password = data['password']
+
+    if email.nil? || password.nil?
+      error_response(err: 'Email and password are required')
+    end
+
+    # generate jwt token
+    payload = { email: email }
+    token = JWT.encode payload, JWT_SECRET, 'HS256'
+
+    # save user to db
+    user = User.new(email: email, password: password, token: token)
+    user.save
+
+    json_response(code: 201, data: { token: token })
+  end
   
 
 end

--- a/api/app/controllers/user_controller.rb
+++ b/api/app/controllers/user_controller.rb
@@ -1,0 +1,8 @@
+require 'sinatra'
+require 'jwt'
+
+class UserController < Sinatra::Base
+
+  
+
+end


### PR DESCRIPTION
This pull request adds a user registration endpoint to the Sinatra application. The endpoint accepts a POST request with JSON data containing the user's email and password. Upon successful registration, a JSON Web Token (JWT) is generated for the user, which can be used to authenticate future requests. The UserController class has been created to handle the /register endpoint. The class includes error handling for missing email and password fields in the JSON data, allows cross-origin requests, and generates a JWT token for the user upon successful registration.

Changes Made
- Added a new UserController class to handle user registration.
- Added a new /register endpoint to the application for user registration.
- Defined a post request handler for the /register endpoint in the UserController class.
- Extracted the email and password fields from the JSON data passed in the request body.
- Included error handling to check if the email and password fields are present in the JSON data.
- Generated a JWT token for the user upon successful registration.
- Return the generated JWT token in the response in JSON format.
